### PR TITLE
Fix container restart problems by forcing to overwrite any existing c…

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,7 @@ set -u
 sed -i 's#OS_URL_REPLACE#'"$OS_URL"'#g' /app/mapproxy.yaml
 
 echo Create start script
-mapproxy-util create -t wsgi-app -f /app/mapproxy.yaml /app/app.py
+mapproxy-util create -t wsgi-app -f /app/mapproxy.yaml --force /app/app.py
 
 echo Starting server
 uwsgi --wsgi-file /app/app.py --wsgi-disable-file-wrapper


### PR DESCRIPTION
…onfiguration

The error mesage after docker-compose restart mapprox was:

*** Operational MODE: preforking ***
WSGI app 0 (mountpoint='') ready in 0 seconds on interpreter 0x55b09de768b0 pid: 16 (default app)
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI master process (pid: 16)
spawned uWSGI worker 1 (pid: 23, cores: 1)
spawned uWSGI worker 2 (pid: 24, cores: 1)
spawned uWSGI worker 3 (pid: 25, cores: 1)
spawned uWSGI worker 4 (pid: 26, cores: 1)
spawned uWSGI http 1 (pid: 27)
Create start script
ERROR: /app/app.py already exists, use --force