### PR TITLE
Fixes all detected CVE's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 *.iml
 mapproxy-local.yaml
+local

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea/
 *.iml
+mapproxy-local.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/python3.6
+FROM amsterdam/python:3.9-bullseye
 LABEL maintainer="datapunt@amsterdam.nl"
 
 EXPOSE 8000
@@ -15,7 +15,7 @@ COPY src/* /app/
 COPY log.ini /app/log.ini
 COPY docker-entrypoint.sh /bin
 
-RUN pip install MapProxy==1.13.2
+RUN pip install MapProxy==1.14.0
 
 USER datapunt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY src/* /app/
 COPY docker-entrypoint.sh /bin
 
-RUN pip install MapProxy==1.13.1
+RUN pip install MapProxy==1.13.2
 
 USER datapunt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN chown datapunt -R /app
 WORKDIR /app
 
 COPY src/* /app/
+COPY log.ini /app/log.ini
 COPY docker-entrypoint.sh /bin
 
 RUN pip install MapProxy==1.13.2

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ Run this for local development
 
 ```bash
   mapproxy-util serve-develop mapproxy-local.yaml
-
 ```
 
-This will spawn a hot reloading wmts server which serves from the objectstore. Note that the demo project
-only only works from zoomlevel 5 but the generated OpenLayers client starts on 0, so you have to zoom to
-see the tiles appear.
+This will spawn a hot reloading wmts server which serves from the objectstore. Note that the layers only work
+starting from zoomlevel 5 but the generated OpenLayers client does not take the constraints of the layers
+into account, so you have to zoom to see the tiles appear.
+
+In this local setup, tms tiles are cached in the `local` directory, which can grow to considerable size if all zoomlevels are requested.
 
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
-# mapproxy
+## Overview
 
 This repository contains a [MapProxy application](https://mapproxy.org/) for the Datapunt Map project. See [here](https://dev.azure.com/CloudCompetenceCenter/Data%20Diensten/_wiki/wikis/Data-Diensten.wiki/3030/Map-project) for a schematic overview of the current architecture.
 Within this project it serves multiple purposes:
 
-    * provide configuration and shell-scripts to pre-generate tiles using the [Amsterdam mapserver](https://github.com/Amsterdam/mapserver) WMS as input
-    * provide a UWSGI-based WMTS server to serve these pre-generated tile-images from a storage backend (typically an objectstore)
-        * The WMTS server automatically uses all configured layers with a name and a single cached source
+    1 provide configuration and shell-scripts to pre-generate tiles using the [Amsterdam mapserver](https://github.com/Amsterdam/mapserver) WMS as input
+    2 provide a UWSGI-based WMTS server to serve these pre-generated tile-images from a storage backend (typically an objectstore)
 
-`mapproxy.yaml` - Mapproxy generic config, this defines the services, sources, caches, layers and globals
-`seed.yaml` - Mapproxy cache configuration, this defines which sources should be used to pre-generate tiles and to what destinations these should be written.
+The WMTS server automatically uses all configured layers with a name and a single cached source
 
-Running this for local development
+## Config files
+
+`mapproxy-base.yaml` - Shared globals and grids for the WMTS server and seeding jobs
+`mapproxy.yaml` - MapProxy WMTS config, this defines the service, sources, caches, layers and globals for the WMTS server.
+`mapproxy-seed.yaml` - Defines the sources and caches used in seeding the basiskaarten and luchtfotos.
+`seed.yaml` - MapProxy cache configuration, this defines which sources should be used to pre-generate tiles and to what destinations these should be written.
+
+Run this for local development
 
 ```bash
-    docker-compose up database mapproxy mapserver
+  mapproxy-util serve-develop mapproxy-local.yaml
+
 ```
 
-This will spawn a mapproxy that consumes WMS from the mapserver container and serves WMTS from the acceptance objectstore.
+This will spawn a hot reloading wmts server which serves from the objectstore. Note that the demo project
+only only works from zoomlevel 5 but the generated OpenLayers client starts on 0, so you have to zoom to
+see the tiles appear.
 
 ---------------------
 
@@ -58,7 +66,7 @@ globals:
 Creating a new Lufo year of tiles and service follow these steps:
 
 - Copy the aerial pictures (tif) to localhost
-- Run mapserver/lufopyramids.sh (see comments in file)
+- Run [lufopyramids.sh in mapserver repo](https://github.com/Amsterdam/mapserver/blob/master/tools/lufopyramids.sh) (see comments in file)
 - Start mapserver docker
 - Run mapproxy docker:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 #     - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
 
   mapserver:
-    image: docker-registry.data.amsterdam.nl/datapunt/mapserver-tiles:2
+    image: mapserver_map
     user: root
     environment:
       BAG_DB_HOST: database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       UWSGI_HTTP: "0.0.0.0:8000"
       UWSGI_MASTER: 1
       UWSGI_PROCESSES: 4
-      OS_URL: "e4b811595a6f4b4aac96f600b037d3dd.objectstore.eu" # Acceptance Tiles as default
+      OS_URL: "devbbn1mapssa.blob.core.windows.net/pyramid" # Devlopment tiles as default
 
   database:
     image: amsterdam/postgres11

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,5 +9,11 @@ sed -i 's#OS_URL_REPLACE#'"$OS_URL"'#g' /app/mapproxy.yaml
 echo Create start script
 mapproxy-util create -t wsgi-app -f /app/mapproxy.yaml --force /app/app.py
 
+cat >> /app/app.py <<- EOM
+from logging.config import fileConfig
+import os.path
+fileConfig("/app/log.ini", {"here": os.path.dirname(__file__)})
+EOM
+
 echo Starting server
 uwsgi --wsgi-file /app/app.py --wsgi-disable-file-wrapper

--- a/log.ini
+++ b/log.ini
@@ -1,0 +1,31 @@
+[loggers]
+keys=root,source_requests
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=default,requests
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[logger_source_requests]
+level=DEBUG
+qualname=mapproxy.source.request
+# propagate=0 -> do not show up in logger_root
+propagate=0
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=requests
+args=(sys.stdout,)
+
+[formatter_default]
+format=%(asctime)s - %(levelname)s - %(name)s - %(message)s
+
+[formatter_requests]
+format=[%(asctime)s] %(message)s

--- a/src/mapproxy-base.yaml
+++ b/src/mapproxy-base.yaml
@@ -1,0 +1,26 @@
+grids:
+  nl_grid:
+    srs: EPSG:28992
+    tile_size: [256,256]
+    origin: sw
+    res: [3440.64,1720.32,860.16,430.08,215.04,107.52,53.76,26.88,13.44,6.72,3.36,1.68,0.84,0.42,0.21,0.105,0.0525]
+    #     0       1       2      3      4      5      6     7     8     9    10   11   12   13   14   15    16
+    bbox: [-285401.920,22598.080,595401.9199999999,903401.9199999999]
+
+  webmercator:
+    base: GLOBAL_WEBMERCATOR
+    num_levels: 22
+
+globals:
+  cache:
+    base_dir: '/app'
+    lock_dir: '/app'
+    tile_lock_dir: '/app'
+    meta_size: [4, 4]
+    meta_buffer: 254
+  http:
+    ssl_no_cert_checks: True
+    client_timeout: 600
+
+  image:
+      resampling_method: bicubic

--- a/src/mapproxy-seed.yaml
+++ b/src/mapproxy-seed.yaml
@@ -1,0 +1,141 @@
+## Configuration for seeding tiles from mapserver WMS
+
+base: [mapproxy-base.yaml]
+caches:
+#### TOPO RD - KBK & BGT
+
+# Standaard kleur
+  topo_rd_cache:
+    grids: [nl_grid]
+    sources: [topografie]
+    cache_dir: /mnt/tiles
+    cache:
+      type: file
+      directory_layout: tms
+
+# Light kleur
+  topo_rd_light_cache:
+    grids: [nl_grid]
+    sources: [topografie_light]
+    cache_dir: /mnt/tiles
+    cache:
+      type: file
+      directory_layout: tms
+
+# Zwartwit
+  topo_rd_zw_cache:
+    grids: [nl_grid]
+    sources: [topografie_zw]
+    cache_dir: /mnt/tiles
+    cache:
+      type: file
+      directory_layout: tms
+
+#### TOPO Webmercator (wm) - KBK & BGT
+
+# Standaard kleur
+  topo_wm_cache:
+    grids: [webmercator]
+    sources: [topografie_wm]
+    cache_dir: /mnt/tiles
+    cache:
+      type: file
+      directory_layout: tms
+
+# Light kleur
+  topo_wm_light_cache:
+    grids: [webmercator]
+    sources: [topografie_wm_light]
+    cache_dir: /mnt/tiles
+    cache:
+      type: file
+      directory_layout: tms
+
+ # Zwartwit
+  topo_wm_zw_cache:
+    grids: [webmercator]
+    sources: [topografie_wm_zw]
+    cache_dir: /mnt/tiles
+    cache:
+      type: file
+      directory_layout: tms
+
+# Luchtfoto's
+  lufo_rd_cache:
+    grids: [nl_grid]
+    sources: [lufo_wms]
+    cache_dir: /mnt/tiles
+    format: image/jpeg
+    cache:
+      type: file
+      directory_layout: tms
+  lufo_wm_cache:
+    grids: [webmercator]
+    sources: [lufo_wms]
+    cache_dir: /mnt/tiles
+    format: image/jpeg
+    cache:
+      type: file
+      directory_layout: tms
+
+sources:
+# basiskaart standaard kleur
+  topografie:
+    type: wms
+    req:
+      url: http://mapserver/maps/topografie
+      layers: basiskaart
+    seed_only: true
+    concurrent_requests: 10
+
+ # basiskaart light kleur
+  topografie_light:
+    type: wms
+    req:
+      url: http://mapserver/maps/topografie
+      layers: basiskaart-light
+    seed_only: true
+    concurrent_requests: 10
+
+# basiskaart zwartwit kleur
+  topografie_zw:
+    type: wms
+    req:
+      url: http://mapserver/maps/topografie
+      layers: basiskaart-zwartwit
+    seed_only: true
+    concurrent_requests: 10
+
+# basiskaart webmercator (wm)
+  topografie_wm:
+    type: wms
+    req:
+      url: http://mapserver/maps/topografie_wm
+      layers: basiskaart
+    seed_only: true
+    concurrent_requests: 10
+
+# basiskaart wm light
+  topografie_wm_light:
+    type: wms
+    req:
+      url: http://mapserver/maps/topografie_wm
+      layers: basiskaart-light
+    seed_only: true
+    concurrent_requests: 10
+
+# basiskaart wm zwartwit
+  topografie_wm_zw:
+    type: wms
+    req:
+      url: http://mapserver/maps/topografie_wm
+      layers: basiskaart-zwartwit
+    seed_only: true
+    concurrent_requests: 10
+
+## Example to tile locally with the mapserver docker also running:
+#  lufo_wms:
+#    type: wms
+#    req:
+#      url: http://mapserver/maps/lufo
+#      layers: lufo-TILE

--- a/src/mapproxy.yaml
+++ b/src/mapproxy.yaml
@@ -1,3 +1,6 @@
+## Configuration for WMTS service
+
+base: [mapproxy-base.yaml]
 services:
   demo:
   wmts:
@@ -64,234 +67,68 @@ caches:
   topo_rd_tiles:
     grids: [nl_grid]
     sources: [basiskaart_rd_tiles]
-
-  topo_rd_cache:
-    grids: [nl_grid]
-    sources: [topografie]
-    cache_dir: /mnt/tiles
-    cache:
-      type: file
-      directory_layout: tms
-
 #### TOPO RD - KBK & BGT - Light kleur
   topo_rd_light_tiles:
     grids: [nl_grid]
     sources: [basiskaart_rd_light_tiles]
-
-  topo_rd_light_cache:
-    grids: [nl_grid]
-    sources: [topografie_light]
-    cache_dir: /mnt/tiles
-    cache:
-      type: file
-      directory_layout: tms
-
 #### TOPO RD - KBK & BGT - Zwartwit
   topo_rd_zw_tiles:
     grids: [nl_grid]
     sources: [basiskaart_rd_zw_tiles]
-
-  topo_rd_zw_cache:
-    grids: [nl_grid]
-    sources: [topografie_zw]
-    cache_dir: /mnt/tiles
-    cache:
-      type: file
-      directory_layout: tms
-
 #### TOPO Webmercator (wm) - KBK & BGT - Standaard kleur
   topo_wm_tiles:
     grids: [webmercator]
     sources: [basiskaart_wm_tiles]
-
-  topo_wm_cache:
-    grids: [webmercator]
-    sources: [topografie_wm]
-    cache_dir: /mnt/tiles
-    cache:
-      type: file
-      directory_layout: tms
-
 #### TOPO wm - KBK & BGT - Light kleur
   topo_wm_light_tiles:
     grids: [webmercator]
     sources: [basiskaart_wm_light_tiles]
-
-  topo_wm_light_cache:
-    grids: [webmercator]
-    sources: [topografie_wm_light]
-    cache_dir: /mnt/tiles
-    cache:
-      type: file
-      directory_layout: tms
-
  ### TOPO Webmercator (wm) - KBK & BGT - Zwartwit
   topo_wm_zw_tiles:
     grids: [webmercator]
     sources: [basiskaart_wm_zw_tiles]
-
-  topo_wm_zw_cache:
-    grids: [webmercator]
-    sources: [topografie_wm_zw]
-    cache_dir: /mnt/tiles
-    cache:
-      type: file
-      directory_layout: tms
-
 # Luchtfoto's
   lufo_rd_tiles:
     grids: [nl_grid]
     sources: [luchtfoto_rd_tiles]
     format: image/jpeg
-
   lufo_wm_tiles:
     grids: [webmercator]
     sources: [luchtfoto_wm_tiles]
     format: image/jpeg
 
-  lufo_rd_cache:
-    grids: [nl_grid]
-    sources: [lufo_wms]
-    cache_dir: /mnt/tiles
-    format: image/jpeg
-    cache:
-      type: file
-      directory_layout: tms
-
-  lufo_wm_cache:
-    grids: [webmercator]
-    sources: [lufo_wms]
-    cache_dir: /mnt/tiles
-    format: image/jpeg
-    cache:
-      type: file
-      directory_layout: tms
-
 sources:
 # basiskaart standaard kleur
-  topografie:
-    type: wms
-    req:
-      url: http://mapserver/maps/topografie
-      layers: basiskaart
-    seed_only: true
-    concurrent_requests: 10
-
   basiskaart_rd_tiles:
     type: tile
     grid: nl_grid
     url: http://OS_URL_REPLACE/topo_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
-
- # basiskaart light kleur
-  topografie_light:
-    type: wms
-    req:
-      url: http://mapserver/maps/topografie
-      layers: basiskaart-light
-    seed_only: true
-    concurrent_requests: 10
-
   basiskaart_rd_light_tiles:
     type: tile
     grid: nl_grid
     url: http://OS_URL_REPLACE/topo_rd_light_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
-
-# basiskaart zwartwit kleur
-  topografie_zw:
-    type: wms
-    req:
-      url: http://mapserver/maps/topografie
-      layers: basiskaart-zwartwit
-    seed_only: true
-    concurrent_requests: 10
-
   basiskaart_rd_zw_tiles:
     type: tile
     grid: nl_grid
     url: http://OS_URL_REPLACE/topo_rd_zw_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
-
-# basiskaart webmercator (wm)
-  topografie_wm:
-    type: wms
-    req:
-      url: http://mapserver/maps/topografie_wm
-      layers: basiskaart
-    seed_only: true
-    concurrent_requests: 10
-
   basiskaart_wm_tiles:
     type: tile
     grid: webmercator
     url: http://OS_URL_REPLACE/topo_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
-
-# basiskaart wm light
-  topografie_wm_light:
-    type: wms
-    req:
-      url: http://mapserver/maps/topografie_wm
-      layers: basiskaart-light
-    seed_only: true
-    concurrent_requests: 10
-
   basiskaart_wm_light_tiles:
     type: tile
     grid: webmercator
     url: http://OS_URL_REPLACE/topo_wm_light_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
-
 # basiskaart wm zwartwit
-  topografie_wm_zw:
-    type: wms
-    req:
-      url: http://mapserver/maps/topografie_wm
-      layers: basiskaart-zwartwit
-    seed_only: true
-    concurrent_requests: 10
-
   basiskaart_wm_zw_tiles:
     type: tile
     grid: webmercator
     url: http://OS_URL_REPLACE/topo_wm_zw_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
-
-# Example to tile locally with the mapserver docker also running:
   luchtfoto_rd_tiles:
     type: tile
     grid: nl_grid
     url: http://OS_URL_REPLACE/lufo2021_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.jpeg
-
   luchtfoto_wm_tiles:
     type: tile
     grid: webmercator
     url: http://OS_URL_REPLACE/lufo2021_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.jpeg
-
-  lufo_wms:
-    type: wms
-    req:
-      url: http://172.17.0.1/maps/lufo
-      layers: lufo-TILE
-
-grids:
-  nl_grid:
-    srs: EPSG:28992
-    tile_size: [256,256]
-    origin: sw
-    res: [3440.64,1720.32,860.16,430.08,215.04,107.52,53.76,26.88,13.44,6.72,3.36,1.68,0.84,0.42,0.21,0.105,0.0525]
-    #     0       1       2      3      4      5      6     7     8     9    10   11   12   13   14   15    16
-    bbox: [-285401.920,22598.080,595401.9199999999,903401.9199999999]
-
-  webmercator:
-    base: GLOBAL_WEBMERCATOR
-    num_levels: 22
-
-globals:
-  cache:
-    base_dir: '/app'
-    lock_dir: '/app'
-    tile_lock_dir: '/app'
-    meta_size: [4, 4]
-    meta_buffer: 254
-  http:
-    ssl_no_cert_checks: True
-    client_timeout: 600
-
-  image:
-      resampling_method: bicubic

--- a/src/mapproxy.yaml
+++ b/src/mapproxy.yaml
@@ -21,7 +21,7 @@ services:
         fax: n/a
         email: datapunt@amsterdam.nl
         fees: 'None'
-    restful: false
+    restful: true
     kvp: true
 
 layers:

--- a/src/mapproxy.yaml
+++ b/src/mapproxy.yaml
@@ -102,33 +102,33 @@ sources:
   basiskaart_rd_tiles:
     type: tile
     grid: nl_grid
-    url: http://OS_URL_REPLACE/topo_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
+    url: https://OS_URL_REPLACE/topo_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
   basiskaart_rd_light_tiles:
     type: tile
     grid: nl_grid
-    url: http://OS_URL_REPLACE/topo_rd_light_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
+    url: https://OS_URL_REPLACE/topo_rd_light_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
   basiskaart_rd_zw_tiles:
     type: tile
     grid: nl_grid
-    url: http://OS_URL_REPLACE/topo_rd_zw_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
+    url: https://OS_URL_REPLACE/topo_rd_zw_cache_EPSG28992/%(z)s/%(x)s/%(y)s.png
   basiskaart_wm_tiles:
     type: tile
     grid: webmercator
-    url: http://OS_URL_REPLACE/topo_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
+    url: https://OS_URL_REPLACE/topo_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
   basiskaart_wm_light_tiles:
     type: tile
     grid: webmercator
-    url: http://OS_URL_REPLACE/topo_wm_light_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
+    url: https://OS_URL_REPLACE/topo_wm_light_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
 # basiskaart wm zwartwit
   basiskaart_wm_zw_tiles:
     type: tile
     grid: webmercator
-    url: http://OS_URL_REPLACE/topo_wm_zw_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
+    url: https://OS_URL_REPLACE/topo_wm_zw_cache_EPSG3857/%(z)s/%(x)s/%(y)s.png
   luchtfoto_rd_tiles:
     type: tile
     grid: nl_grid
-    url: http://OS_URL_REPLACE/lufo2021_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.jpeg
+    url: https://OS_URL_REPLACE/lufo2021_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.jpeg
   luchtfoto_wm_tiles:
     type: tile
     grid: webmercator
-    url: http://OS_URL_REPLACE/lufo2021_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.jpeg
+    url: https://OS_URL_REPLACE/lufo2021_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.jpeg

--- a/src/seed.yaml
+++ b/src/seed.yaml
@@ -1,5 +1,7 @@
-seeds:
+## Configuration for the mapproxy-seed tool
 
+
+seeds:
 #### TOPO RD - KBK & BGT - Standaard kleur
   topo_rd_kbk:
     caches: [topo_rd_cache]


### PR DESCRIPTION
Updates the base image to amsterdam/python:3.9-bullseye and bumps Mapproxy to 1.14

Base image fixes:
[DLA 2972-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00004.html)
[DLA 2976-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00007.html)
[DLA 2977-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00008.html)
[DLA 2968-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00000.html)
[DLA 2975-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00006.html)
[DLA 2963-1](https://lists.debian.org/debian-lts-announce/2022/03/msg00036.html)
[CVE-2019-18276](https://security-tracker.debian.org/tracker/CVE-2019-18276)

Mapproxy:

Improvements:

- Refresh while serving (#518).
- Enabled commandline option skip uncached (#515)
- Several dependencies updated
- Support for python 3.5 has been dropped because of its EOL, 3.9 has been added

Fixes:

- Several minor bugfixes
- Security fix to avoid potential web cache poisoning.

