### PR TITLE
Fix all detected CVE's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/python3.6
+FROM amsterdam/python:3.9-bullseye
 LABEL maintainer="datapunt@amsterdam.nl"
 
 EXPOSE 8000
@@ -15,7 +15,7 @@ COPY src/* /app/
 COPY log.ini /app/log.ini
 COPY docker-entrypoint.sh /bin
 
-RUN pip install MapProxy==1.13.2
+RUN pip install MapProxy==1.14.0
 
 USER datapunt
 


### PR DESCRIPTION
Updates the base image to amsterdam/python:3.9-bullseye and bumps Mapproxy to 1.14

Base image fixes:
[DLA 2972-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00004.html)
[DLA 2976-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00007.html)
[DLA 2977-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00008.html)
[DLA 2968-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00000.html)
[DLA 2975-1](https://lists.debian.org/debian-lts-announce/2022/04/msg00006.html)
[DLA 2963-1](https://lists.debian.org/debian-lts-announce/2022/03/msg00036.html)
[CVE-2019-18276](https://security-tracker.debian.org/tracker/CVE-2019-18276)

Mapproxy:

Improvements:
- Refresh while serving (#518).
- Enabled commandline option skip uncached (#515)
- Several dependencies updated
- Support for python 3.5 has been dropped because of its EOL, 3.9 has been added

Fixes:
- Several minor bugfixes
- Security fix to avoid potential web cache poisoning.