### PR TITLE
Use 2022 aerial image cache for layers 'lufo_rd' and 'lufo_wm'.

### DIFF
--- a/src/mapproxy.yaml
+++ b/src/mapproxy.yaml
@@ -256,12 +256,12 @@ sources:
   luchtfoto_rd_tiles:
     type: tile
     grid: nl_grid
-    url: http://OS_URL_REPLACE/lufo2021_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.jpeg
+    url: http://OS_URL_REPLACE/lufo2022_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.jpeg
 
   luchtfoto_wm_tiles:
     type: tile
     grid: webmercator
-    url: http://OS_URL_REPLACE/lufo2021_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.jpeg
+    url: http://OS_URL_REPLACE/lufo2022_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.jpeg
 
   lufo_wms:
     type: wms


### PR DESCRIPTION
The WMS and WMTS (REST) services are based on lufo_2022 cache. However, the WMTS (KVP) service was still pulling tiles from the lufo_2021 cache. Should be fixed with this PR.