### PR TITLE
Use 2023 tiles for aerial imagery 🛩️.

### DIFF
--- a/src/mapproxy.yaml
+++ b/src/mapproxy.yaml
@@ -256,12 +256,12 @@ sources:
   luchtfoto_rd_tiles:
     type: tile
     grid: nl_grid
-    url: http://OS_URL_REPLACE/lufo2022_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.jpeg
+    url: http://OS_URL_REPLACE/lufo2023_rd_cache_EPSG28992/%(z)s/%(x)s/%(y)s.jpeg
 
   luchtfoto_wm_tiles:
     type: tile
     grid: webmercator
-    url: http://OS_URL_REPLACE/lufo2022_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.jpeg
+    url: http://OS_URL_REPLACE/lufo2023_wm_cache_EPSG3857/%(z)s/%(x)s/%(y)s.jpeg
 
   lufo_wms:
     type: wms


### PR DESCRIPTION
Aerial imagery 🛩️ for 2023 is available as pre-generated tiles in the Object Store. Let's use them :tada: 