### PR TITLE
Correctly set reference systems. Also legacy 900913 for OVL-application.

### DIFF
--- a/src/mapproxy.yaml
+++ b/src/mapproxy.yaml
@@ -18,7 +18,7 @@ services:
         fax: n/a
         email: datapunt@amsterdam.nl
         fees: 'None'
-    srs: ['28992']
+    srs: ['EPSG:3857','EPSG:28992', 'EPSG:900913']
   wmts:
     md:
       # metadata used in capabilities documents


### PR DESCRIPTION
Previously, projection array only contained the code number. Now contains also the 'EPSG:' prefix. Added [900913](https://epsg.io/900913) (1337-speak for Google) projection to support the Openbare Verlichting (OVL) application that still uses this deprecated code for "Web Mercator" or "Spherical Mercator" instead of the official [3857](https://epsg.io/3857).