### PR TITLE
Yrob/fix base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/python:3.9.6-bullseye
+FROM python:3.9-bullseye
 LABEL maintainer="datapunt@amsterdam.nl"
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY src/* /app/
 COPY log.ini /app/log.ini
 COPY docker-entrypoint.sh /bin
 
-RUN pip install MapProxy==1.14.0
+RUN pip install MapProxy==1.16.0
 
 USER datapunt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       UWSGI_HTTP: "0.0.0.0:8000"
       UWSGI_MASTER: 1
       UWSGI_PROCESSES: 4
-      OS_URL: "dpbk-o-bhbuh2chc3evemgn.a01.azurefd.net" # Acceptance Tiles as default
+      OS_URL: "${OS_URL:-t1.acc.data.amsterdam.nl}" # Acceptance Tiles as default

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 uwsgi==2.0.26
-pyproj==3.2.1
+pyproj==3.6.1


### PR DESCRIPTION
Move away from old amsterdam python image. It is no longer available. (We fixed this before but a dependabot update seems to have undone this. Probably a badly resolved merge conflict.)