### PR TITLE
Add env variable to point MapProxy to the right Front Door instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This repository contains a [MapProxy application](https://mapproxy.org/) for the
 Run this for local development
 
 ```bash
-    docker-compose up
+    setx OS_URL "t1.data.amsterdam.nl"
+    docker compose up
 ```
 
 This will spawn a MapProxy container that serves WMTS and WMS services from the acceptance object store that contains pre-generated tiles.


### PR DESCRIPTION
Only small change to prepare local testing of MapProxy for serving tiles.