### PR TITLE
Remove db and update compose syntax.

### DIFF
--- a/start_tiles.sh
+++ b/start_tiles.sh
@@ -6,8 +6,8 @@ set -u
 DIR="$(dirname $0)"
 
 dc() {
-	docker-compose pull
-	docker-compose -p mapproxy -f ${DIR}/docker-compose.yml $*
+	docker compose pull
+	docker compose -p mapproxy -f ${DIR}/compose.yml $*
 }
 
 trap 'dc kill ; dc rm -f' EXIT
@@ -15,8 +15,6 @@ trap 'dc kill ; dc rm -f' EXIT
 # clean environment
 dc down
 
-# start database
-dc up -d --force-recreate database
 # Start mapserver
 dc up -d mapserver
 sleep 10
@@ -25,13 +23,5 @@ sleep 10
 sudo mkdir -p /mnt/tiles
 sudo chmod 755 /mnt/tiles
 
-# import basiskaart db
-dc exec -T database update-db.sh basiskaart
-dc exec -T database update-db.sh bag_v11
-
-
-# generate geojson
 dc build
-docker cp src/indexes.sh "$(dc ps -q database)":/tmp/indexes.sh
-dc exec database psql -U basiskaart -d basiskaart -f /tmp/indexes.sh
 dc run topo_$1


### PR DESCRIPTION
Simply, we can't bring up a database anymore. So we leave this out. Also, we don't ingest any data nor run any indexes.
Furthermore, the compose syntax has changed (also see https://github.com/Amsterdam/mapproxy/pull/46/commits/3919df28177140d6830abc043b06878be6e8410f).